### PR TITLE
Remove duplicate TestClient import

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -1,7 +1,6 @@
 from fastapi.testclient import TestClient
 from api import app
 from unittest.mock import MagicMock, patch
-from fastapi.testclient import TestClient
 import pytest
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary
- deduplicate `TestClient` import in test_api.py

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683f3b758628833180d5f6debd458c12