### PR TITLE
Handle unavailable database

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -135,6 +135,8 @@ async def on_message(message):
                     await message.channel.send(result)
                 else:
                     await message.reply(result)
+            elif response.status_code == 503:
+                await message.channel.send("Service indisponible : base de données hors ligne")
             else:
                 await message.channel.send("❌ Erreur API.")
         except Exception as e:


### PR DESCRIPTION
## Summary
- Raise HTTP 503 when database connection or cursor is missing
- Guard thread retrieval against missing database cursor
- Notify Discord users when API reports database outage

## Testing
- `export OPENAI_API_KEY='test'`
- `export OPENAI_ASSISTANT_ID='test_assistant'`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aec7aff57483318595c872bd61dd9d